### PR TITLE
Fix Vercel deploy: add missing pillow and ffmpeg-python deps

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,4 +4,6 @@ llm
 llm-anthropic
 llm-ollama
 llm-whisper-api
+pillow>=12.1.1
+ffmpeg-python>=0.2.0
 sqlite-utils


### PR DESCRIPTION
## Summary
- Add `pillow>=12.1.1` and `ffmpeg-python>=0.2.0` to `requirements.txt`
- These are required by `share.py` (reel video and audiobook generation) but were missing, causing Vercel Preview deployments to fail with `ModuleNotFoundError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)